### PR TITLE
Add FreeBSD support

### DIFF
--- a/src/Network/Http/Inconvenience.hs
+++ b/src/Network/Http/Inconvenience.hs
@@ -230,11 +230,7 @@ baselineContextSSL :: IO SSLContext
 baselineContextSSL = do
     ctx <- SSL.context
     SSL.contextSetDefaultCiphers ctx
-#if defined __MACOSX__
-    SSL.contextSetVerificationMode ctx SSL.VerifyNone
-#elif defined __WINDOWS__
-    SSL.contextSetVerificationMode ctx SSL.VerifyNone
-#else
+#if defined __LINUX__
     fedora <- doesDirectoryExist "/etc/pki/tls"
     if fedora
         then do
@@ -242,6 +238,10 @@ baselineContextSSL = do
         else do
             SSL.contextSetCADirectory ctx "/etc/ssl/certs"
     SSL.contextSetVerificationMode ctx $ SSL.VerifyPeer True True Nothing
+#elif defined __FREEBSD__
+    SSL.contextSetCAFile ctx "/usr/local/share/certs/ca-root-nss.crt"
+#else
+    SSL.contextSetVerificationMode ctx SSL.VerifyNone
 #endif
     return ctx
 


### PR DESCRIPTION
Compilation failed on FreeBSD, as doesDirectoryExist is imported if `__LINUX__` is defined, but called if neither `__MACOSX__` nor `__WINDOWS__` are defined. The patch fixes this by only calling it if `__LINUX__` is defined (so, if it was imported), uses the correct CA file for FreeBSD (installed by the port `security/ca_root_nss`), and falls back on not verifying the certificates for other OSes. Support for other Unix variants shouldn't be too hard to add too, but I don't have any other right now to test (from what I gathered, OpenBSD stores a `cert.pem` directly in `/etc/ssl`, DragonFlyBSD does the same as FreeBSD, and I don't know about NetBSD nor other Unixes).
