### PR TITLE
Add support for Unix domain sockets.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -64,6 +64,9 @@ Change Log
 
 Recent API changes:
 
+* _v0.8.0_  
+	Support for Unix domain socket has been added.
+
 * _v0.7.0_  
 	The Request, Response, Headers, and RequestBuilder types have been
 	factored out and moved to **http-common**. They are still exported

--- a/http-streams.cabal
+++ b/http-streams.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >= 1.10
 name:                http-streams
-version:             0.7.2.0
+version:             0.8.0.0
 synopsis:            An HTTP client using io-streams
 description:
  /Overview/

--- a/src/Network/Http/Client.hs
+++ b/src/Network/Http/Client.hs
@@ -97,6 +97,7 @@ module Network.Http.Client (
     Port,
     Connection,
     openConnection,
+    openConnectionUnix,
 
     -- * Building Requests
     -- | You setup a request using the RequestBuilder monad, and

--- a/src/Network/Http/Inconvenience.hs
+++ b/src/Network/Http/Inconvenience.hs
@@ -158,8 +158,8 @@ modifyContextSSL f = do
     writeIORef global ctx'
 
 --
--- | Given a URL, work out whether it is normal or secure, and then
--- open the connection to the webserver including setting the
+-- | Given a URL, work out whether it is normal, secure, or unix domain,
+-- and then open the connection to the webserver including setting the
 -- appropriate default port if one was not specified in the URL. This
 -- is what powers the convenience API, but you may find it useful in
 -- composing your own similar functions.
@@ -190,6 +190,8 @@ establish u =
         "https:" -> withOpenSSL $ do
                         ctx <- readIORef global
                         openConnectionSSL ctx host ports
+        "unix:"  -> do
+                        openConnectionUnix $ uriPath u
         _        -> error ("Unknown URI scheme " ++ scheme)
   where
     scheme = uriScheme u


### PR DESCRIPTION
Does exactly what it says on the tin.

The only weird thing is that the `cHost` field in the `Connection` data type is set to the socket filepath. It seems to be only used in its `Show` instance.

Maybe instead of displaying "Host: ", it should display "Socket: " or similar.