### PR TITLE
Missing network-uri dependency (?)

### DIFF
--- a/http-streams.cabal
+++ b/http-streams.cabal
@@ -40,6 +40,7 @@ library
                      io-streams >= 1.1 && <1.3,
                      HsOpenSSL >= 0.10.3.5,
                      openssl-streams >= 1.1 && <1.2,
+                     network-uri,
                      mtl,
                      transformers,
                      network,


### PR DESCRIPTION
I found that http-streams didn't compile without me adding a network-uri dependency when using a ghc 7.8. 
This might be just re-organization of various packages, so it might need an ifdef to work on older ghc's. I don't have an one handy, so I can't test it right now.

(ie. "I don't really know what I'm doing but heres a patch which makes stuff compile")
