### PR TITLE
Fix ambiquity due to generalised `elem`

### DIFF
--- a/lib/Network/Http/Inconvenience.hs
+++ b/lib/Network/Http/Inconvenience.hs
@@ -126,7 +126,7 @@ urlEncodeTable = HashSet.fromList $! filter f $! map w2c [0..255]
     f c | c >= 'A' && c <= 'Z' = True
         | c >= 'a' && c <= 'z' = True
         | c >= '0' && c <= '9' = True
-    f c = c `elem` "$-_.!~*'(),"
+    f c = c `elem` ("$-_.!~*'(),"::String)
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
In base-4.8, elem has been generalised to `Foldable`, so in
combination with `-XOverloadedStrings`, something like `\c -> elem c "abc"`
can't be type-inferred anymore.

(cherry picked from commit 8728dc0651506b6d9f1d92635439bcc9aa5e4a71)