### PR TITLE
updated dependencies of io-streams and blaze-builder to match, bumped to 0.8.0.3

### DIFF
--- a/http-streams.cabal
+++ b/http-streams.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >= 1.10
 name:                http-streams
-version:             0.8.0.2
+version:             0.8.0.3
 synopsis:            An HTTP client using io-streams
 description:
  /Overview/
@@ -38,10 +38,10 @@ library
                      base >= 4 && <5,
                      directory,
                      base64-bytestring,
-                     blaze-builder,
                      bytestring,
                      case-insensitive,
-                     io-streams >= 1.1 && <1.4,
+                     -- io-streams >= 1.1 && < 1.3, blaze-builder < 0.4,
+                     io-streams >= 1.3, blaze-builder >= 0.4,
                      HsOpenSSL >= 0.10.3.5,
                      openssl-streams >= 1.1 && < 1.4,
                      mtl,


### PR DESCRIPTION
Changed the dependencies to match.

Though I'm not entirely sure, if this was the right way (choosing the newer versions) -- to use 'http-streams' I also had to clone 'http-common' as that was not on hackage. Now, this latter library will probably be updated with http-streams together :). BUT, there are other libraries in hackage (e.g web-routes) which don't allow for the new builder and will therefore cause some pain to users. In short, going with the old builder might be the practical choice.