### PR TITLE
Add FreeBSD support and verify certificates

### DIFF
--- a/lib/Network/Http/Inconvenience.hs
+++ b/lib/Network/Http/Inconvenience.hs
@@ -242,6 +242,7 @@ baselineContextSSL = do
     SSL.contextSetVerificationMode ctx SSL.VerifyNone
 #elif defined __FREEBSD__
     SSL.contextSetCAFile ctx "/usr/local/etc/ssl/cert.pem"
+    SSL.contextSetVerificationMode ctx $ SSL.VerifyPeer True True Nothing
 #else
     fedora <- doesDirectoryExist "/etc/pki/tls"
     if fedora

--- a/lib/Network/Http/Inconvenience.hs
+++ b/lib/Network/Http/Inconvenience.hs
@@ -240,6 +240,8 @@ baselineContextSSL = do
     SSL.contextSetVerificationMode ctx SSL.VerifyNone
 #elif defined __WINDOWS__
     SSL.contextSetVerificationMode ctx SSL.VerifyNone
+#elif defined __FREEBSD__
+    SSL.contextSetCAFile ctx "/usr/local/etc/ssl/cert.pem"
 #else
     fedora <- doesDirectoryExist "/etc/pki/tls"
     if fedora
@@ -615,4 +617,3 @@ jsonHandler _ i = do
     case r of
         (Success a) ->  return a
         (Error str) ->  error str
-


### PR DESCRIPTION
Includes #95, and also verifies certificates.

```
$ stack exec -- ghci tests/SecureSocketsSnippet.hs
GHCi, version 7.10.3: http://www.haskell.org/ghc/  :? for help
[1 of 1] Compiling Snippet          ( tests/SecureSocketsSnippet.hs, interpreted )
Ok, modules loaded: Snippet.
*Snippet> get "https://www.example.com" debugHandler
HTTP/1.1 200 OK
...etc...
*Snippet> get "https://expired.badssl.com" debugHandler
*** Exception: ProtocolError "error:14090086:SSL routines:ssl3_get_server_certificate:certificate verify failed"
```
