### PR TITLE
Fix build on FreeBSD systems.

### DIFF
--- a/lib/Network/Http/Inconvenience.hs
+++ b/lib/Network/Http/Inconvenience.hs
@@ -76,7 +76,7 @@ import Network.Http.Connection
 import Network.Http.RequestBuilder
 import Network.Http.Types
 
-#if defined __LINUX__
+#if defined __LINUX__ || defined __FREEBSD__
 import System.Directory (doesDirectoryExist)
 #endif
 


### PR DESCRIPTION
On FreeBSD machines, import module `System.Directory` where the function `doesDirectoryExist` is defined. Now this builds on FreeBSD 11.

Build error message was:
```
    [1 of 2] Compiling Main             ( /tmp/stack41819/http-streams-0.8.4.0/Setup.hs, /tmp/stack41819/http-streams-0.8.4.0/.stack-work/dist/x86_64-freebsd/Cabal-1.22.5.0/setup/Main.o )
    [2 of 2] Compiling StackSetupShim   ( /usr/home/nbrk/.stack/setup-exe-src/setup-shim-mPHDZzAJ.hs, /tmp/stack41819/http-streams-0.8.4.0/.stack-work/dist/x86_64-freebsd/Cabal-1.22.5.0/setup/StackSetupShim.o )
    Linking /tmp/stack41819/http-streams-0.8.4.0/.stack-work/dist/x86_64-freebsd/Cabal-1.22.5.0/setup/setup ...
    Configuring http-streams-0.8.4.0...
    Building http-streams-0.8.4.0...
    Preprocessing library http-streams-0.8.4.0...
    [1 of 5] Compiling Network.Http.Utilities ( lib/Network/Http/Utilities.hs, .stack-work/dist/x86_64-freebsd/Cabal-1.22.5.0/build/Network/Http/Utilities.o )
    [2 of 5] Compiling Network.Http.ResponseParser ( lib/Network/Http/ResponseParser.hs, .stack-work/dist/x86_64-freebsd/Cabal-1.22.5.0/build/Network/Http/ResponseParser.o )
    [3 of 5] Compiling Network.Http.Connection ( lib/Network/Http/Connection.hs, .stack-work/dist/x86_64-freebsd/Cabal-1.22.5.0/build/Network/Http/Connection.o )
    [4 of 5] Compiling Network.Http.Inconvenience ( lib/Network/Http/Inconvenience.hs, .stack-work/dist/x86_64-freebsd/Cabal-1.22.5.0/build/Network/Http/Inconvenience.o )
    
    /tmp/stack41819/http-streams-0.8.4.0/lib/Network/Http/Inconvenience.hs:244:15:
        Not in scope: ‘doesDirectoryExist’
```