### PR TITLE
Fix inaccurate version bounds

### DIFF
--- a/http-streams.cabal
+++ b/http-streams.cabal
@@ -41,8 +41,8 @@ extra-source-files:  README.markdown CHANGELOG.markdown
 build-type:          Custom
 
 custom-setup
-  setup-depends:     base >= 4,
-                     Cabal
+  setup-depends:     base >= 4.5,
+                     Cabal >= 1.24
 
 flag network-uri
    description: Get Network.URI from the network-uri package
@@ -52,14 +52,14 @@ library
   default-language:  Haskell2010
 
   build-depends:     attoparsec,
-                     base >= 4 && <5,
+                     base >= 4.5 && <5,
                      directory,
                      base64-bytestring,
                      blaze-builder >= 0.4,
                      bytestring,
                      case-insensitive,
                      io-streams >= 1.3 && < 1.6,
-                     HsOpenSSL >= 0.10.3.5,
+                     HsOpenSSL >= 0.11.2,
                      openssl-streams >= 1.1 && < 1.4,
                      mtl,
                      transformers,


### PR DESCRIPTION
This fixes various build-failures such as

```
n order, the following will be built (use -v for more details):
 - http-streams-0.8.5.5 {http-streams-0.8.5.5-inplace} (lib:http-streams) (first run)
[1 of 1] Compiling Main             ( /tmp/matrix-worker/1512471502/dist-newstyle/build/x86_64-linux/ghc-7.10.3/http-streams-0.8.5.5/setup/setup.hs, /tmp/matrix-worker/1512471502/dist-newstyle/build/x86_64-linux/ghc-7.10.3/http-streams-0.8.5.5/setup/Main.o )
Linking /tmp/matrix-worker/1512471502/dist-newstyle/build/x86_64-linux/ghc-7.10.3/http-streams-0.8.5.5/setup/setup ...
<<ghc: 367077192 bytes, 161 GCs, 10987147/28796560 avg/max bytes residency (8 samples), 81M in use, 0.002 INIT (0.002 elapsed), 0.167 MUT (3.151 elapsed), 0.326 GC (0.330 elapsed) :ghc>>
Warning: http-streams.cabal: This package requires at least Cabal version 1.24
Warning: http-streams.cabal: Ignoring unknown section type: custom-setup
Configuring http-streams-0.8.5.5...
setup: This package description follows version 1.24 of the Cabal
specification. This tool only supports up to version 1.22.5.0.
```

or 

```
In order, the following will be built (use -v for more details):
 - http-streams-0.8.5.5 {http-streams-0.8.5.5-inplace} (lib:http-streams) (first run)
[1 of 1] Compiling Main             ( /tmp/matrix-worker/1512471677/dist-newstyle/build/x86_64-linux/ghc-7.8.4/http-streams-0.8.5.5/setup/setup.hs, /tmp/matrix-worker/1512471677/dist-newstyle/build/x86_64-linux/ghc-7.8.4/http-streams-0.8.5.5/setup/Main.o )
Linking /tmp/matrix-worker/1512471677/dist-newstyle/build/x86_64-linux/ghc-7.8.4/http-streams-0.8.5.5/setup/setup ...
Configuring http-streams-0.8.5.5...
Preprocessing library for http-streams-0.8.5.5..
Building library for http-streams-0.8.5.5..
[1 of 5] Compiling Network.Http.Utilities ( lib/Network/Http/Utilities.hs, /tmp/matrix-worker/1512471677/dist-newstyle/build/x86_64-linux/ghc-7.8.4/http-streams-0.8.5.5/build/Network/Http/Utilities.o )
[2 of 5] Compiling Network.Http.ResponseParser ( lib/Network/Http/ResponseParser.hs, /tmp/matrix-worker/1512471677/dist-newstyle/build/x86_64-linux/ghc-7.8.4/http-streams-0.8.5.5/build/Network/Http/ResponseParser.o )
[3 of 5] Compiling Network.Http.Connection ( lib/Network/Http/Connection.hs, /tmp/matrix-worker/1512471677/dist-newstyle/build/x86_64-linux/ghc-7.8.4/http-streams-0.8.5.5/build/Network/Http/Connection.o )

lib/Network/Http/Connection.hs:239:5:
    Not in scope: ‘SSL.setTlsextHostName’
```

I've already revised the affected releases on Hackage, so there's no need/benefit of uploading a new release.

However, going forward I think `Setup.hs` is not needed as the platform logic it performs is redundant as GHC/Cabal already provide builtin facilities to achieve the same w/o the trouble of using a custom `Setup.hs`.

Let me know if you're interested in having me provide you with a PR that achieves that.