### PR TITLE
unsafeReceiveResponse that does not consume body

### DIFF
--- a/lib/Network/Http/Client.hs
+++ b/lib/Network/Http/Client.hs
@@ -133,6 +133,7 @@ module Network.Http.Client (
     -- * Processing HTTP response
     receiveResponse,
     receiveResponseRaw,
+    unsafeReceiveResponse,
     UnexpectedCompression,
     StatusCode,
     getStatusCode,


### PR DESCRIPTION
This works when you know there is no body, no matter what the headers
say (HEAD requests, #114)

This also works when the handler consumes whatever part of the body you
actually want to use, and then you close the connection afterwards (no
reusing for pipelining!)  Sometimes this is a lot faster than using
pipelining if you can, for example, skip a many GB download (#113)